### PR TITLE
Fix Google GenAI import

### DIFF
--- a/gui_agents/s2/core/engine.py
+++ b/gui_agents/s2/core/engine.py
@@ -11,8 +11,8 @@ from openai import (
     OpenAI,
     RateLimitError,
 )
-from google import genai
-from google.genai import types
+import google.generativeai as genai
+from google.generativeai import types
 
 
 class LMMEngine:


### PR DESCRIPTION
## Summary
- fix import for Google's generative AI client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gui_agents')*

------
https://chatgpt.com/codex/tasks/task_e_68892f4a2dbc832db7305f47b4b42a41