### PR TITLE
Default provider openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ We also support Azure OpenAI, Anthropic, Gemini, Open Router, and vLLM inference
 
 ### Quickstart with OpenAI
 
-If you prefer to use OpenAI's models exclusively, make sure your `OPENAI_API_KEY` environment variable is set as shown above. Then launch the agent with the `--provider` flag set to `openai` and specify your desired OpenAI model. For example:
+OpenAI is the default provider. Ensure your `OPENAI_API_KEY` environment variable is set as shown above, then launch the agent and specify your desired OpenAI model (the `--provider` flag is optional). For example:
 
 ```bash
 agent_s2 \

--- a/gui_agents/s2/cli_app.py
+++ b/gui_agents/s2/cli_app.py
@@ -144,13 +144,13 @@ def main():
     parser.add_argument(
         "--provider",
         type=str,
-        default="anthropic",
+        default="openai",
         help="Specify the provider to use (e.g., openai, anthropic, etc.)",
     )
     parser.add_argument(
         "--model",
         type=str,
-        default="claude-3-7-sonnet-20250219",
+        default="gpt-4o",
         help="Specify the model to use (e.g., gpt-4o)",
     )
     parser.add_argument(
@@ -170,13 +170,13 @@ def main():
     parser.add_argument(
         "--grounding_model_provider",
         type=str,
-        default="anthropic",
+        default="openai",
         help="Specify the provider to use for the grounding model (e.g., openai, anthropic, etc.)",
     )
     parser.add_argument(
         "--grounding_model",
         type=str,
-        default="claude-3-7-sonnet-20250219",
+        default="gpt-4o",
         help="Specify the grounding model to use (e.g., claude-3-5-sonnet-20241022)",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- default to `openai` provider in `gui_agents/s2/cli_app.py`
- update README to mention OpenAI as default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gui_agents', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6889312f8a50832d9fe65fee55ca63c8